### PR TITLE
Fixed namespace mismatch and restored test references (HT)

### DIFF
--- a/Tests/AuthRepositoryTest.cs
+++ b/Tests/AuthRepositoryTest.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
-using JetInteriorApp.Data;
-using JetInteriorApp.Models;
-using JetInteriorApp.Repositories;
-using JetInteriorApp.Services;
+using JIDS.Data;
+using JIDS.Models;
+using JIDS.Repositories;
+using JIDS.Services;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 

--- a/Tests/AuthenticationIntegrationTest.cs
+++ b/Tests/AuthenticationIntegrationTest.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using JetInteriorApp.Data;
-using JetInteriorApp.Repositories;
-using JetInteriorApp.ViewModels;
+using JIDS.Data;
+using JIDS.Repositories;
+using JIDS.ViewModels;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 

--- a/Tests/ConfigurationManagerTests.cs
+++ b/Tests/ConfigurationManagerTests.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using JetInteriorApp.Models;
-using JetInteriorApp.Services.Configuration;
-using JetInteriorApp.Interfaces;
+using JIDS.Models;
+using JIDS.Services.Configuration;
+using JIDS.Interfaces;
 using Moq;
 using Xunit;
 

--- a/Tests/DatabaseTest.cs
+++ b/Tests/DatabaseTest.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using JetInteriorApp.Models;
-using JetInteriorApp.Data;
+using JIDS.Models;
+using JIDS.Data;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 

--- a/Tests/LoginViewModelTests.cs
+++ b/Tests/LoginViewModelTests.cs
@@ -1,8 +1,8 @@
-﻿using JetInteriorApp.Data;
-using JetInteriorApp.Helpers;
-using JetInteriorApp.Interfaces;
-using JetInteriorApp.Models;
-using JetInteriorApp.ViewModels;
+﻿using JIDS.Data;
+using JIDS.Helpers;
+using JIDS.Interfaces;
+using JIDS.Models;
+using JIDS.ViewModels;
 using Moq;
 using System;
 using System.Threading.Tasks;

--- a/Tests/PasswordHasherTests.cs
+++ b/Tests/PasswordHasherTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using JetInteriorApp.Services;
+using JIDS.Services;
 using Xunit;
 
 public class PasswordHasherTests

--- a/Tests/RelayCommandTests.cs
+++ b/Tests/RelayCommandTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using JetInteriorApp.Helpers;
+using JIDS.Helpers;
 using Xunit;
 
 public class RelayCommandTests


### PR DESCRIPTION
- Replaced all legacy 'JetInteriorApp' namespaces with 'JIDS' to align with current architecture.
- Reconnected test project to JIDS.csproj.
- Verified build success, and restored test functionality on macOS using EnableWindowsTargeting flag.

This fix restored functionality for the testing environment and allowed me to continue QA validation on my local Mac setup.